### PR TITLE
Update `dispatch` hook to have utilization metrics

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -38,7 +38,7 @@ module Shoryuken
         return sleep(MIN_DISPATCH_INTERVAL)
       end
 
-      fire_event(:dispatch, false, queue_name: queue.name)
+      fire_event(:dispatch, false, busy: busy, queue_name: queue.name, ready: ready)
 
       logger.debug { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{@polling_strategy.active_queues}" }
 


### PR DESCRIPTION
I'd like to export metrics from Shoryuken so that we have metrics available for the number of worker threads busy at any given time. The logical thing to do is to put the metrics in the `dispatch` lifecycle hook, but right now they don't have that information available.

I'm suggesting that we add that information to the arguments that are passed to the hook, so that it is available within the hook.